### PR TITLE
Skip occurrences

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,6 +23,7 @@ import {MatTableModule} from '@angular/material/table';
 import { NetFlowIconComponent } from './components/net-flow-icon/net-flow-icon.component';
 import {MatToolbarModule} from '@angular/material/toolbar';
 import {MatMenuModule} from '@angular/material/menu';
+import {MatListModule} from '@angular/material/list';
 import { FileSaveDialogComponent } from './components/file-save-dialog/file-save-dialog.component';
 import { SettingsDialogComponent } from './components/settings-dialog/settings-dialog.component';
 import { FrequencyDisplayComponent } from './components/frequency-display/frequency-display.component';
@@ -64,6 +65,7 @@ import { OccurrenceCardComponent } from './components/occurrence-card/occurrence
     MatTableModule,
     MatToolbarModule,
     MatMenuModule,
+    MatListModule,
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/components/edit-transaction-dialog/edit-transaction-dialog.component.html
+++ b/src/app/components/edit-transaction-dialog/edit-transaction-dialog.component.html
@@ -8,6 +8,7 @@
     [(frequency)]="frequency"
     [(interval)]="interval"
     [(startDate)]="startDate"
+    [(skip)]="skip"
     [omitFrequencies]="hideYearly ? ['Yearly'] : []"
   ></app-transaction-form>
 

--- a/src/app/components/edit-transaction-dialog/edit-transaction-dialog.component.spec.ts
+++ b/src/app/components/edit-transaction-dialog/edit-transaction-dialog.component.spec.ts
@@ -84,6 +84,9 @@ describe('EditTransactionDialogComponent (NEW)', () => {
     component.type = TransactionTypes.Expense;
     component.startDate = today;
     component.title = 'Test';
+    component.skip = [
+      today,
+    ]
 
     spyOn(state, 'addTransaction').and.callFake((t) => {
       expect(t.amount).toEqual(1.23);
@@ -93,6 +96,7 @@ describe('EditTransactionDialogComponent (NEW)', () => {
       expect(t.recurrence.frequency).toEqual(Frequency.Daily);
       expect(t.recurrence.interval).toEqual(12);
       expect(t.recurrence.startDate).toEqual(today);
+      expect(t.skip).toEqual([today]);
     });
 
     component.onSaveClick();

--- a/src/app/components/edit-transaction-dialog/edit-transaction-dialog.component.spec.ts
+++ b/src/app/components/edit-transaction-dialog/edit-transaction-dialog.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatListModule } from '@angular/material/list';
 import { By } from '@angular/platform-browser';
 import { EditTransactionDialogTypes } from 'src/app/models/edit-transaction-dialog-data';
 import { Frequency } from 'src/app/models/recurrence';
@@ -21,6 +22,7 @@ describe('EditTransactionDialogComponent (NEW)', () => {
       ],
       imports: [
         MatDialogModule,
+        MatListModule,
       ],
       providers: [
         { provide: MatDialogRef, useValue: { close: function() {} }},
@@ -128,6 +130,7 @@ describe('Edit Incomes', () => {
       ],
       imports: [
         MatDialogModule,
+        MatListModule,
       ],
       providers: [
         { provide: MatDialogRef, useValue: { close: function() {} }},

--- a/src/app/components/edit-transaction-dialog/edit-transaction-dialog.component.spec.ts
+++ b/src/app/components/edit-transaction-dialog/edit-transaction-dialog.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
-import { EditTransactionDialogData, EditTransactionDialogTypes } from 'src/app/models/edit-transaction-dialog-data';
+import { EditTransactionDialogTypes } from 'src/app/models/edit-transaction-dialog-data';
 import { Frequency } from 'src/app/models/recurrence';
 import { Transaction, TransactionTypes } from 'src/app/models/transaction';
 import { AppStateService } from 'src/app/services/state/app-state.service';

--- a/src/app/components/edit-transaction-dialog/edit-transaction-dialog.component.ts
+++ b/src/app/components/edit-transaction-dialog/edit-transaction-dialog.component.ts
@@ -36,7 +36,7 @@ export class EditTransactionDialogComponent {
 
     if (data.dialogType == EditTransactionDialogTypes.Edit) {
       this.transactionId = data.id;
-      this._fetchTransactionData();
+      this.fetchTransactionData();
     } else {
       this.title = '';
       this.amount = 0;
@@ -53,7 +53,7 @@ export class EditTransactionDialogComponent {
   }
 
   public onSaveClick(): void {
-    const transaction: Transaction = this._build();
+    const transaction: Transaction = this.build();
 
     if (transaction.id === 0) {
       this.state.addTransaction(transaction);
@@ -64,7 +64,7 @@ export class EditTransactionDialogComponent {
     this.dialogRef.close();
   }
 
-  private _fetchTransactionData(): void {
+  private fetchTransactionData(): void {
     const transaction: Transaction | undefined = this.state.transactions.find((t: Transaction) => t.id === this.transactionId);
 
     if (!transaction) {
@@ -73,10 +73,10 @@ export class EditTransactionDialogComponent {
       return;
     }
 
-    this._parse(transaction);
+    this.parse(transaction);
   }
 
-  private _parse(transaction: Transaction): void {
+  private parse(transaction: Transaction): void {
     this.transactionId = transaction.id;
     this.amount = transaction.amount;
     this.title = transaction.title;
@@ -87,7 +87,7 @@ export class EditTransactionDialogComponent {
     this.startDate = transaction.recurrence.startDate;
   }
 
-  private _build(): Transaction {
+  private build(): Transaction {
     const transaction: Transaction = new Transaction(this.title, this.amount, this.type);
 
     transaction.id = this.transactionId;

--- a/src/app/components/edit-transaction-dialog/edit-transaction-dialog.component.ts
+++ b/src/app/components/edit-transaction-dialog/edit-transaction-dialog.component.ts
@@ -17,6 +17,7 @@ export class EditTransactionDialogComponent {
   public interval!: number;
   public type!: TransactionTypes;
   public startDate!: Date;
+  public skip!: Date[];
   public titleType!: string;
   public hideYearly: boolean = false;
 
@@ -42,6 +43,7 @@ export class EditTransactionDialogComponent {
       this.frequency = Frequency.Monthly;
       this.interval = 1;
       this.startDate = new Date();
+      this.skip = [];
       this.startDate.setHours(0, 0, 0, 0);
     }
   }
@@ -79,6 +81,7 @@ export class EditTransactionDialogComponent {
     this.amount = transaction.amount;
     this.title = transaction.title;
     this.type = transaction.type;
+    this.skip = transaction.skip;
     this.frequency = transaction.recurrence.frequency;
     this.interval = transaction.recurrence.interval;
     this.startDate = transaction.recurrence.startDate;
@@ -88,6 +91,7 @@ export class EditTransactionDialogComponent {
     const transaction: Transaction = new Transaction(this.title, this.amount, this.type);
 
     transaction.id = this.transactionId;
+    transaction.skip = this.skip;
     transaction.recurrence.frequency = this.frequency;
     transaction.recurrence.interval = this.interval;
     transaction.recurrence.startDate = this.startDate;

--- a/src/app/components/edit-transaction-dialog/edit-transaction-dialog.component.ts
+++ b/src/app/components/edit-transaction-dialog/edit-transaction-dialog.component.ts
@@ -20,21 +20,21 @@ export class EditTransactionDialogComponent {
   public titleType!: string;
   public hideYearly: boolean = false;
 
-  private _transactionId: number = 0;
+  private transactionId: number = 0;
 
   constructor(
-    private _state: AppStateService,
-    private _ref: MatDialogRef<EditTransactionDialogComponent>,
+    private state: AppStateService,
+    private dialogRef: MatDialogRef<EditTransactionDialogComponent>,
     @Inject(MAT_DIALOG_DATA) data: EditTransactionDialogData
   ) {
-    this._transactionId = data.id;
+    this.transactionId = data.id;
     this.type = data.type;
     this.titleType = this.type == TransactionTypes.Expense
       ? 'expense' : 'income';
     this.hideYearly = this.type == TransactionTypes.Income;
 
     if (data.dialogType == EditTransactionDialogTypes.Edit) {
-      this._transactionId = data.id;
+      this.transactionId = data.id;
       this._fetchTransactionData();
     } else {
       this.title = '';
@@ -54,20 +54,20 @@ export class EditTransactionDialogComponent {
     const transaction: Transaction = this._build();
 
     if (transaction.id === 0) {
-      this._state.addTransaction(transaction);
+      this.state.addTransaction(transaction);
     } else {
-      this._state.updateTransaction(transaction);
+      this.state.updateTransaction(transaction);
     }
 
-    this._ref.close();
+    this.dialogRef.close();
   }
 
   private _fetchTransactionData(): void {
-    const transaction: Transaction | undefined = this._state.transactions.find((t: Transaction) => t.id === this._transactionId);
+    const transaction: Transaction | undefined = this.state.transactions.find((t: Transaction) => t.id === this.transactionId);
 
     if (!transaction) {
       alert('An error occurred opening the transaction for edit!');
-      this._ref.close();
+      this.dialogRef.close();
       return;
     }
 
@@ -75,7 +75,7 @@ export class EditTransactionDialogComponent {
   }
 
   private _parse(transaction: Transaction): void {
-    this._transactionId = transaction.id;
+    this.transactionId = transaction.id;
     this.amount = transaction.amount;
     this.title = transaction.title;
     this.type = transaction.type;
@@ -87,7 +87,7 @@ export class EditTransactionDialogComponent {
   private _build(): Transaction {
     const transaction: Transaction = new Transaction(this.title, this.amount, this.type);
 
-    transaction.id = this._transactionId;
+    transaction.id = this.transactionId;
     transaction.recurrence.frequency = this.frequency;
     transaction.recurrence.interval = this.interval;
     transaction.recurrence.startDate = this.startDate;

--- a/src/app/components/transaction-form/transaction-form.component.html
+++ b/src/app/components/transaction-form/transaction-form.component.html
@@ -35,5 +35,48 @@
     <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
     <mat-datepicker #picker></mat-datepicker>
   </mat-form-field>
+
+  <mat-expansion-panel class="mb-5">
+    <mat-expansion-panel-header>
+      <mat-panel-title>
+        Advanced
+      </mat-panel-title>
+    </mat-expansion-panel-header>
+
+    <div class="container">
+      <div class="d-flex justify-content-between align-items-center">
+        <mat-form-field appearance="fill" class="w-75">
+          <mat-label>Skip a day</mat-label>
+          <input matInput [matDatepicker]="skipPicker" [(ngModel)]="newSkipDate">
+          <mat-datepicker-toggle matSuffix [for]="skipPicker"></mat-datepicker-toggle>
+          <mat-datepicker #skipPicker></mat-datepicker>
+        </mat-form-field>
+        <button mat-button
+          [disabled]="!newSkipDate"
+          color="primary"
+          (click)="onNewSkipDateSave()">Add</button>
+      </div>
+
+      <mat-divider></mat-divider>
+
+      <div class="mt-3">
+        <div class="d-flex justify-content-between align-items-center">
+          <h6 *ngIf="skip">
+            {{ skip.length }} skipped dates
+          </h6>
+          <button mat-button
+            [disabled]="!canRemove"
+            color="warn"
+            (click)="onRemoveSkippedDates()">Remove</button>
+        </div>
+
+        <mat-selection-list #skippedDates>
+          <mat-list-option *ngFor="let day of skip" [value]="day">
+            {{ day | date }}
+          </mat-list-option>
+        </mat-selection-list>
+      </div>
+    </div>
+  </mat-expansion-panel>
 </div>
 

--- a/src/app/components/transaction-form/transaction-form.component.html
+++ b/src/app/components/transaction-form/transaction-form.component.html
@@ -52,7 +52,7 @@
           <mat-datepicker #skipPicker></mat-datepicker>
         </mat-form-field>
         <button mat-button
-          [disabled]="!newSkipDate"
+          [disabled]="!canSaveSkipDate"
           color="primary"
           (click)="onNewSkipDateSave()">Add</button>
       </div>

--- a/src/app/components/transaction-form/transaction-form.component.spec.ts
+++ b/src/app/components/transaction-form/transaction-form.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatListModule } from '@angular/material/list';
 
 import { TransactionFormComponent } from './transaction-form.component';
 
@@ -8,7 +9,10 @@ describe('TransactionFormComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ TransactionFormComponent ]
+      declarations: [ TransactionFormComponent ],
+      imports: [
+        MatListModule,
+      ]
     })
     .compileComponents();
   });

--- a/src/app/components/transaction-form/transaction-form.component.ts
+++ b/src/app/components/transaction-form/transaction-form.component.ts
@@ -89,6 +89,7 @@ export class TransactionFormComponent implements OnInit, AfterViewInit {
 
     this.newSkipDate.setHours(0, 0, 0, 0);
     const newList: Date[] = [...this.skip, <Date>this.newSkipDate];
+    newList.sort((a: Date, b: Date) => a < b ? -1 : a > b ? 1 : 0);
     this.skipChange.emit(newList);
     this.newSkipDate = undefined;
   }

--- a/src/app/components/transaction-form/transaction-form.component.ts
+++ b/src/app/components/transaction-form/transaction-form.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnInit, EventEmitter, Output, ViewChild, AfterViewInit } from '@angular/core';
 import { MatListOption, MatSelectionList } from '@angular/material/list';
 import { Frequency } from 'src/app/models/recurrence';
+import 'src/app/extensions/date';
 
 @Component({
   selector: 'app-transaction-form',
@@ -24,7 +25,7 @@ export class TransactionFormComponent implements OnInit, AfterViewInit {
   @ViewChild(MatSelectionList) skippedDates!: MatSelectionList;
   public frequencies: FrequencyDisplay[] = [];
   public newSkipDate: Date | undefined;
-  public canRemove: boolean = false;
+  public areSkipDateListValuesSelected: boolean = false;
 
   get frequencyDisplay(): string {
     switch (this.frequency) {
@@ -39,6 +40,22 @@ export class TransactionFormComponent implements OnInit, AfterViewInit {
       default:
         return '';
     }
+  }
+
+  public get canRemove(): boolean {
+    return this.areSkipDateListValuesSelected;
+  }
+
+  public get canSaveSkipDate(): boolean {
+    if (!this.newSkipDate) {
+      return false;
+    }
+
+    if (this.skip.some(s => s.isSameDate(<Date>this.newSkipDate))) {
+      return false;
+    }
+
+    return true;
   }
 
   ngOnInit(): void {
@@ -61,12 +78,18 @@ export class TransactionFormComponent implements OnInit, AfterViewInit {
 
   ngAfterViewInit(): void {
     this.skippedDates.selectedOptions.changed.subscribe(() => {
-      this.canRemove = this.skippedDates.selectedOptions.hasValue();
+      this.areSkipDateListValuesSelected = this.skippedDates.selectedOptions.hasValue();
     });
   }
 
   public onNewSkipDateSave(): void {
-    this.skipChange.emit([...this.skip, <Date>this.newSkipDate]);
+    if (!this.newSkipDate) {
+      return;
+    }
+
+    this.newSkipDate.setHours(0, 0, 0, 0);
+    const newList: Date[] = [...this.skip, <Date>this.newSkipDate];
+    this.skipChange.emit(newList);
     this.newSkipDate = undefined;
   }
 

--- a/src/app/components/transaction-form/transaction-form.component.ts
+++ b/src/app/components/transaction-form/transaction-form.component.ts
@@ -77,7 +77,7 @@ export class TransactionFormComponent implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit(): void {
-    this.skippedDates.selectedOptions.changed.subscribe(() => {
+    this.skippedDates.selectedOptions?.changed.subscribe(() => {
       this.areSkipDateListValuesSelected = this.skippedDates.selectedOptions.hasValue();
     });
   }

--- a/src/app/components/transaction-form/transaction-form.component.ts
+++ b/src/app/components/transaction-form/transaction-form.component.ts
@@ -1,4 +1,5 @@
-import { Component, Input, OnInit, EventEmitter, Output } from '@angular/core';
+import { Component, Input, OnInit, EventEmitter, Output, ViewChild, AfterViewInit } from '@angular/core';
+import { MatListOption, MatSelectionList } from '@angular/material/list';
 import { Frequency } from 'src/app/models/recurrence';
 
 @Component({
@@ -6,7 +7,7 @@ import { Frequency } from 'src/app/models/recurrence';
   templateUrl: './transaction-form.component.html',
   styleUrls: ['./transaction-form.component.sass']
 })
-export class TransactionFormComponent implements OnInit {
+export class TransactionFormComponent implements OnInit, AfterViewInit {
   @Input() public title!: string;
   @Output() public titleChange = new EventEmitter<string>();
   @Input() public amount!: number;
@@ -17,8 +18,13 @@ export class TransactionFormComponent implements OnInit {
   @Output() public intervalChange = new EventEmitter<number>();
   @Input() public startDate!: Date;
   @Output() public startDateChange = new EventEmitter<Date>();
+  @Input() public skip!: Date[];
+  @Output() public skipChange = new EventEmitter<Date[]>();
   @Input() public omitFrequencies: string[] | undefined;
+  @ViewChild(MatSelectionList) skippedDates!: MatSelectionList;
   public frequencies: FrequencyDisplay[] = [];
+  public newSkipDate: Date | undefined;
+  public canRemove: boolean = false;
 
   get frequencyDisplay(): string {
     switch (this.frequency) {
@@ -51,6 +57,24 @@ export class TransactionFormComponent implements OnInit {
         this.frequencies = this.frequencies.filter(f => !f.name.includes(frequencyString));
       }
     }
+  }
+
+  ngAfterViewInit(): void {
+    this.skippedDates.selectedOptions.changed.subscribe(() => {
+      this.canRemove = this.skippedDates.selectedOptions.hasValue();
+    });
+  }
+
+  public onNewSkipDateSave(): void {
+    this.skipChange.emit([...this.skip, <Date>this.newSkipDate]);
+    this.newSkipDate = undefined;
+  }
+
+  public onRemoveSkippedDates(): void {
+    const datesToRemove: Date[] = this.skippedDates.selectedOptions.selected
+      .map((option: MatListOption) => <Date>option.value);
+    const newSkippedDates: Date[] = this.skip.filter((skippedDate: Date) => !datesToRemove.includes(skippedDate));
+    this.skipChange.emit(newSkippedDates);
   }
 }
 

--- a/src/app/components/transaction/transaction.component.html
+++ b/src/app/components/transaction/transaction.component.html
@@ -16,9 +16,9 @@
           [interval]="transaction.recurrence.interval"
           [date]="transaction.recurrence.startDate"></app-frequency-display>
         <span *ngIf="transaction.recurrence.frequency !== 0">
-          &nbsp;beginning
+          beginning
         </span>
-        <span>&nbsp;on {{ transaction.recurrence.startDate | date }}.</span>
+        <span>on {{ transaction.recurrence.startDate | date }}.</span>
       </p>
     </mat-card-subtitle>
   </mat-card-header>

--- a/src/app/components/transaction/transaction.component.html
+++ b/src/app/components/transaction/transaction.component.html
@@ -20,12 +20,9 @@
         </span>
         <span>on {{ transaction.recurrence.startDate | date }}.</span>
       </p>
-      <mat-list *ngIf="transaction.skip.length">
-        Skips:
-        <mat-list-item *ngFor="let day of transaction.skip">
-          {{ day | date }}
-        </mat-list-item>
-      </mat-list>
+      <div *ngIf="transaction.skip.length">
+        Skips {{ skipList }}
+      </div>
     </mat-card-subtitle>
   </mat-card-header>
 </mat-card>

--- a/src/app/components/transaction/transaction.component.html
+++ b/src/app/components/transaction/transaction.component.html
@@ -20,6 +20,12 @@
         </span>
         <span>on {{ transaction.recurrence.startDate | date }}.</span>
       </p>
+      <mat-list *ngIf="transaction.skip.length">
+        Skips:
+        <mat-list-item *ngFor="let day of transaction.skip">
+          {{ day | date }}
+        </mat-list-item>
+      </mat-list>
     </mat-card-subtitle>
   </mat-card-header>
 </mat-card>

--- a/src/app/components/transaction/transaction.component.ts
+++ b/src/app/components/transaction/transaction.component.ts
@@ -1,3 +1,4 @@
+import { DatePipe } from '@angular/common';
 import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { EditTransactionDialogData, EditTransactionDialogTypes } from 'src/app/models/edit-transaction-dialog-data';
@@ -20,6 +21,26 @@ export class TransactionComponent implements OnInit {
     private _dialog: MatDialog
   ) {
     this.delete = new EventEmitter<void>();
+  }
+
+  public get skipList(): string {
+    const datePipe: DatePipe = new DatePipe('en-US');
+    const dateStrings: string[] = this.transaction.skip
+      .map((s: Date) => <string>datePipe.transform(s));
+
+    if (dateStrings.length === 1) {
+      return dateStrings[0];
+    }
+
+    if (dateStrings.length === 2) {
+      return dateStrings.join(' and ');
+    }
+
+    const last: string = <string>dateStrings.splice(-1)[0];
+    let list: string = dateStrings.join(', ');
+    list += ', and ' + last;
+
+    return list;
   }
 
   public ngOnInit(): void {

--- a/src/app/extensions/date.ts
+++ b/src/app/extensions/date.ts
@@ -1,0 +1,13 @@
+declare global {
+  interface Date {
+    isSameDate(otherDate: Date): boolean;
+  }
+}
+
+Date.prototype.isSameDate = function(otherDate: Date): boolean {
+  return this.getFullYear() === otherDate.getFullYear() &&
+    this.getMonth() === otherDate.getMonth() &&
+    this.getDate() === otherDate.getDate();
+}
+
+export {}

--- a/src/app/models/transaction.spec.ts
+++ b/src/app/models/transaction.spec.ts
@@ -1,3 +1,4 @@
+import { DateRange } from "@angular/material/datepicker";
 import { Frequency } from "./recurrence";
 import { Transaction, TransactionTypes } from "./transaction";
 
@@ -228,6 +229,23 @@ describe('Transaction', () => {
     }
 
     expect(passed).toBeTrue();
+  });
+
+  it('should return false for all dates in the skip array', () => {
+    const skip = [
+      new Date('January 2, 2020'),
+      new Date('January 3, 2020'),
+      new Date('January 4, 2020'),
+    ];
+    const transaction = new Transaction(title, amount, type);
+    transaction.skip = skip;
+    transaction.recurrence.frequency = Frequency.Daily;
+    transaction.recurrence.interval = 1;
+    transaction.recurrence.startDate = new Date('January 1, 2020');
+
+    for (let date of skip) {
+      expect(transaction.occursOn(date)).toBeFalse();
+    }
   });
 });
 

--- a/src/app/services/persistence.service.spec.ts
+++ b/src/app/services/persistence.service.spec.ts
@@ -13,6 +13,7 @@ const title = 'test';
 const frequency = Frequency.Daily;
 const interval = 3;
 const startDate = new Date('January 1, 2020');
+const skip: Date[] = [new Date('January 15, 2020')];
 startDate.setHours(0, 0, 0, 0);
 
 describe('PersistenceService', () => {
@@ -81,14 +82,14 @@ describe('PersistenceService', () => {
   });
 
   it('should parse a json string into a transaction', () => {
-    const json = `[${buildTransactionJson(id, title, amount, type, frequency, interval, startDate)}]`;
+    const json = `[${buildTransactionJson(id, title, amount, type, skip, frequency, interval, startDate)}]`;
     const parsed = service.readJson(json);
 
     expect(parsed.length).toEqual(1);
   });
 
   it('should parse all the transaction data from the json string', () => {
-    const json = `[${buildTransactionJson(id, title, amount, type, frequency, interval, startDate)}]`;
+    const json = `[${buildTransactionJson(id, title, amount, type, skip, frequency, interval, startDate)}]`;
     const parsed = service.readJson(json);
 
     expect(parsed[0].amount).toEqual(amount);
@@ -113,7 +114,7 @@ describe('PersistenceService', () => {
       'startDate',
     ];
 
-    const jsonString = buildTransactionJson(id, title, amount, type, frequency, interval, startDate);
+    const jsonString = buildTransactionJson(id, title, amount, type, skip, frequency, interval, startDate);
 
     for (let prop of properties) {
       const badObj = JSON.parse(jsonString);
@@ -134,6 +135,8 @@ describe('PersistenceService', () => {
 });
 
 
-function buildTransactionJson(id: number, title: string, amount: number, type: TransactionTypes, frequency: Frequency, interval: number, startDate: Date): string {
-  return `{"id":${id},"title":"${title}","amount":${amount},"type":${type},"recurrence":{"frequency":${frequency},"interval":${interval},"startDate":"${startDate.toISOString()}"}}`;
+function buildTransactionJson(id: number, title: string, amount: number, type: TransactionTypes, skip: Date[], frequency: Frequency, interval: number, startDate: Date): string {
+  const skipStrings: string = skip.map(d => d.toISOString()).map(s => `"${s}"`).join(',');
+  const json: string = `{"id":${id},"title":"${title}","amount":${amount},"type":${type},"skip":[${skipStrings}],"recurrence":{"frequency":${frequency},"interval":${interval},"startDate":"${startDate.toISOString()}"}}`;
+  return json;
 }

--- a/src/app/services/persistence.service.spec.ts
+++ b/src/app/services/persistence.service.spec.ts
@@ -106,7 +106,8 @@ describe('PersistenceService', () => {
       'id',
       'amount',
       'title',
-      'type'
+      'type',
+      'skip',
     ];
     const recurrenceProperties = [
       'frequency',

--- a/src/app/services/persistence.service.ts
+++ b/src/app/services/persistence.service.ts
@@ -44,12 +44,14 @@ export class PersistenceService {
     const amount: number = this.extractAndValidateValue(json, 'number', 'amount');
     const id: number = this.extractAndValidateValue(json, 'number', 'id');
     const type: TransactionTypes = this.extractAndValidateValue(json, 'number', 'type');
+    const skip: Date[] = (this.extractAndValidateValue(json, 'object', 'skip') as string[]).map((ds: string) => new Date(ds));
     const interval: number = this.extractAndValidateValue(json, 'number', 'recurrence', 'interval');
     const frequency: number = this.extractAndValidateValue(json, 'number', 'recurrence', 'frequency');
     const startDate: Date = new Date(this.extractAndValidateValue(json, 'string', 'recurrence', 'startDate'));
 
     const transaction: Transaction = new Transaction(title, amount, type);
     transaction.id = id;
+    transaction.skip = skip;
     transaction.recurrence.frequency = frequency;
     transaction.recurrence.interval = interval;
     transaction.recurrence.startDate = startDate;
@@ -63,6 +65,7 @@ export class PersistenceService {
       title: transaction.title,
       amount: transaction.amount,
       type: transaction.type,
+      skip: transaction.skip.map((d: Date) => d.toISOString()),
       recurrence: {
         interval: transaction.recurrence.interval,
         frequency: transaction.recurrence.frequency,


### PR DESCRIPTION
This PR closes #13 by allowing the user to add dates to a transaction that they wish to "skip." This prevents the transaction from being added to any occurrences on that date.